### PR TITLE
Updates score to be unoptimizable

### DIFF
--- a/Bot/Models/MafiaGame.cs
+++ b/Bot/Models/MafiaGame.cs
@@ -92,10 +92,11 @@ namespace TyniBot.Models
 
                     if (isMafia)
                     {
-                        bool guessedMe = Votes.Where(x => x.Value.Contains(user.Key)).Count() > 0;
+                        int numVotesGuessedMe = Votes.Where(x => x.Value.Contains(user.Key)).Count();
+                        int hiddenMafiaScore = 2 - numVotesGuessedMe; // baseline two points for not being guess mafia
 
-                        score += !wonGame ? 2 : 0; // two points for losing
-                        score += !guessedMe ? 3 : 0;
+                        score += !wonGame ? 3 : 0; // three points for losing
+                        score += hiddenMafiaScore > 0 ? hiddenMafiaScore : 0; // points based on guesses
                     }
                     else
                     {


### PR DESCRIPTION
Villager: 1 for team win, 2 for guessing each mafia
Mafia: 3 for losing, 2 points for not being guessed as mafia (one point deduction per guess on you)

Previously, it was more advantageous for the mafia to play well and get 3 points for not being guessed than it was to lose.  I think that the primary goal of the mafia should be to lose.  This variation also only works with 1 mafia on each time. We'll probably have to find a way to fit the 1 mafia game mode as well.