### PR TITLE
Add the player emoji to the scoreboard

### DIFF
--- a/Extensions/Mafia/Source/Output.cs
+++ b/Extensions/Mafia/Source/Output.cs
@@ -101,11 +101,11 @@ namespace Discord.Mafia
 
             var ordered = game.Players.OrderByDescending(x => x.Value.Score);
 
-            embedBuilder.AddField("Score: ", string.Join("\r\n", ordered.Select(p => $"{p.Value.Mention} = {p.Value.Score}")));
+            embedBuilder.AddField("Score: ", string.Join("\r\n", ordered.Select(p => $"{p.Emoji} {p.Value.Mention} = {p.Value.Score}")));
 
-            embedBuilder.AddField("Mafia: ", string.Join(' ', game.Mafia.Select(u => u.Mention)));
+            embedBuilder.AddField("Mafia: ", string.Join(' | ', game.Mafia.Select(u => $"{u.Emoji} {u.Mention}")));
             if (game.Joker != null)
-                embedBuilder.AddField("Joker: ", game.Joker.Mention);
+                embedBuilder.AddField("Joker: ", $"{game.Joker.Emoji} {game.Joker.Mention}");
 
             return await channel.SendMessageAsync($"**Game Over! {ordered.First().Value.Mention} Won!**", false, embedBuilder.Build());
         }


### PR DESCRIPTION
This allows for easier lookup against the vote reactions
Also added a separator character sequence for mafia, to provide further separation between a player's name and the next player's emoji