### PR TITLE
Add admincea configure command.

### DIFF
--- a/Bot/Discord.Bot.Extensions/Cea/Commands/AdminCeaSlashCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/AdminCeaSlashCommand.cs
@@ -1,0 +1,83 @@
+﻿using Discord.Bot;
+using Discord.WebSocket;
+using PlayCEA_RL.Configuration;
+using PlayCEAStats.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public class AdminCeaSlashCommand : SlashCommand
+    {
+        public override string Name => "admincea";
+
+        public override string Description => "Command to update PlayCea Configuration for the bot.";
+
+        public override bool DefaultPermissions => false;
+
+        public override bool IsGlobal => false;
+
+        public override Dictionary<ulong, List<ApplicationCommandPermission>> GuildIdsAndPermissions => new Dictionary<ulong, List<ApplicationCommandPermission>>()
+        {
+            { 902581441727197195, new List<ApplicationCommandPermission> { new ApplicationCommandPermission(903514452463325184, ApplicationCommandPermissionTarget.Role, true) } }, // tynibot test employee
+            { 124366291611025417, new List<ApplicationCommandPermission> { new ApplicationCommandPermission(469941381075435523, ApplicationCommandPermissionTarget.Role, true) } }, // msft rl admin
+        };
+
+        public AdminCeaSlashCommand() : base()
+        {
+        }
+
+        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client)
+        {
+            var subCommand = command.Data.Options.Where(o => o.Type.Equals(ApplicationCommandOptionType.SubCommand)).First();
+            string configuration = (string) subCommand.Options.Where(o => o.Name.Equals("configuration")).First().Value;
+
+            try
+            {
+                BracketConfiguration newConfiguration = JsonSerializer.Deserialize<BracketConfiguration>(configuration);
+                ConfigurationManager.WriteConfiguration(newConfiguration);
+                await command.RespondAsync($"New Configuration Saved.\n{configuration}", ephemeral: true);
+            } 
+            catch (JsonException)
+            {
+                await command.RespondAsync("Invalid BracketConfiguration JSON.", ephemeral: true);
+                throw;
+            }
+            catch (Exception e)
+            {
+                await command.RespondAsync($"Unknown Exception.\n{e}", ephemeral: true);
+                throw;
+            }
+        }
+
+        public override ApplicationCommandProperties Build()
+        {
+            var builder = new SlashCommandBuilder()
+                    .WithName(this.Name)
+                    .WithDescription(this.Description)
+                    .WithDefaultPermission(this.DefaultPermissions);
+
+            SlashCommandOptionBuilder optionBuilder = new SlashCommandOptionBuilder()
+            {
+                Name = "configure",
+                Description = "Gets all match history for a team or teams.",
+                Type = ApplicationCommandOptionType.SubCommand
+            };
+
+            optionBuilder.AddOption(
+                    name: "configuration",
+                    type: ApplicationCommandOptionType.String,
+                    description: "The full JSON configuration for the CEA bot.",
+                    required: true);
+            
+
+            builder.AddOption(optionBuilder);
+
+            return builder.Build();
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/AdminCeaSlashCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/AdminCeaSlashCommand.cs
@@ -2,6 +2,7 @@
 using Discord.WebSocket;
 using PlayCEA_RL.Configuration;
 using PlayCEAStats.DataModel;
+using PlayCEAStats.RequestManagement;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,8 +40,9 @@ namespace Discord.Cea
             try
             {
                 BracketConfiguration newConfiguration = JsonSerializer.Deserialize<BracketConfiguration>(configuration);
-                ConfigurationManager.WriteConfiguration(newConfiguration);
-                await command.RespondAsync($"New Configuration Saved.\n{configuration}", ephemeral: true);
+                ConfigurationManager.UpdateInMemoryConfiguration(newConfiguration);
+                await command.RespondAsync($"New Configuration Set.\n{configuration}", ephemeral: true);
+                LeagueManager.ForceUpdate();
             } 
             catch (JsonException)
             {

--- a/Bot/TyniBot.csproj
+++ b/Bot/TyniBot.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Discord.Net.Labs" Version="3.1.7" />
     <PackageReference Include="LiteDB" Version="5.0.11" />
-	<PackageReference Include="PlayCEA.RLClient" Version="1.1.3" />
+	<PackageReference Include="PlayCEA.RLClient" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bot/TyniBot.csproj
+++ b/Bot/TyniBot.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Discord.Net.Labs" Version="3.1.7" />
     <PackageReference Include="LiteDB" Version="5.0.11" />
-	<PackageReference Include="PlayCEA.RLClient" Version="1.2.1" />
+	<PackageReference Include="PlayCEA.RLClient" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bot/TynibotHost.cs
+++ b/Bot/TynibotHost.cs
@@ -31,6 +31,7 @@ namespace TyniBot
             new RecruitingCommand(),
             new AdminRecruitingCommand(),
             new CeaSlashCommand(),
+            new AdminCeaSlashCommand()
         };
 
         private readonly Dictionary<string, SlashCommand> SlashCommandDictionary;


### PR DESCRIPTION
New CEA library allows for updating the configuration - added an admin command to allow configuring without requiring redeploy. This helps with quickly adjusting when they change brackets, but stable configs should still be checked in.

Tynibot Test - employee, and MSFT RL admin roles have permissions.