### PR TITLE
Add CEA User Commands

### DIFF
--- a/Bot.DockerService/DockerService.csproj
+++ b/Bot.DockerService/DockerService.csproj
@@ -5,7 +5,9 @@
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
     <AssemblyName>TyniBotDockerService</AssemblyName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'TyniBotDockerService' " />
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'TyniBotDockerService' ">
+    <ExternalConsole>true</ExternalConsole>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />

--- a/Bot.DockerService/Properties/launchSettings.json
+++ b/Bot.DockerService/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "TyniBotDockerService": {
       "commandName": "Project",
+      "applicationUrl": "http://localhost:5000/",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }

--- a/Bot/Commands/PingSlashCommand.cs
+++ b/Bot/Commands/PingSlashCommand.cs
@@ -20,7 +20,7 @@ namespace TyniBot.Commands
 
         public override bool IsGlobal => true;
 
-        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient, Guild guild)
+        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient)
         {
             await command.RespondAsync("Pong!");
         }

--- a/Bot/Commands/VersionSlashCommand.cs
+++ b/Bot/Commands/VersionSlashCommand.cs
@@ -23,7 +23,7 @@ namespace TyniBot.Commands
 
         public override bool IsGlobal => true;
 
-        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient, Guild guild)
+        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient)
         {
             var version = FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
 

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaHistoryCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaHistoryCommand.cs
@@ -22,6 +22,11 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
+            return GetEmbed(team);
+        }
+
+        internal static Embed GetEmbed(Team team)
+        {
             EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
             AddFullHistoryToEmbed(builder, team);
             return builder.Build();

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaHistoryCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaHistoryCommand.cs
@@ -22,7 +22,7 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
-            EmbedBuilder builder = new();
+            EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
             AddFullHistoryToEmbed(builder, team);
             return builder.Build();
         }

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaHistoryUserCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaHistoryUserCommand.cs
@@ -1,0 +1,22 @@
+﻿using Discord.Bot;
+using Discord.Bot.Utils;
+using Discord.WebSocket;
+using PlayCEASharp.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public class CeaHistoryUserCommand : CeaUserCommand
+    {
+        public override string Name => "CEA History";
+
+        public override async Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient, Team team)
+        {
+            await command.RespondAsync(embeds:new Embed[] { CeaHistoryCommand.GetEmbed(team)}, ephemeral:true);
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaNextCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaNextCommand.cs
@@ -20,7 +20,7 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
-            EmbedBuilder builder = new();
+            EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
             if (!AddNextMatchToEmbed(builder, team))
             {
                 return null;

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaNextCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaNextCommand.cs
@@ -20,12 +20,17 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
+            return GetEmbed(team);
+        }
+
+        internal static Embed GetEmbed(Team team)
+        {
             EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
             if (!AddNextMatchToEmbed(builder, team))
             {
                 return null;
             }
-            
+
             return builder.Build();
         }
 

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaNextUserCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaNextUserCommand.cs
@@ -1,0 +1,22 @@
+﻿using Discord.Bot;
+using Discord.Bot.Utils;
+using Discord.WebSocket;
+using PlayCEASharp.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public class CeaNextUserCommand : CeaUserCommand
+    {
+        public override string Name => "CEA Next";
+
+        public override async Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient, Team team)
+        {
+            await command.RespondAsync(embeds:new Embed[] { CeaNextCommand.GetEmbed(team)}, ephemeral:true);
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaPreviewCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaPreviewCommand.cs
@@ -20,6 +20,11 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
+            return GetEmbed(team);
+        }
+
+        internal static Embed GetEmbed(Team team)
+        {
             League league = LeagueManager.League;
             if (!league.NextMatchLookup.ContainsKey(team))
             {

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaPreviewUserCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaPreviewUserCommand.cs
@@ -1,0 +1,30 @@
+﻿using Discord.Bot;
+using Discord.Bot.Utils;
+using Discord.WebSocket;
+using PlayCEASharp.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public class CeaPreviewUserCommand : CeaUserCommand
+    {
+        public override string Name => "CEA Preview";
+
+        public override async Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient, Team team)
+        {
+            Embed response = CeaPreviewCommand.GetEmbed(team);
+
+            if (response == null)
+            {
+                await command.RespondAsync($"No next match found for {team.Name}.");
+                return;
+            }
+
+            await command.RespondAsync(embeds:new Embed[] { response }, ephemeral:true);
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaRecordCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaRecordCommand.cs
@@ -20,7 +20,7 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
-            EmbedBuilder builder = new();
+            EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
 
             AddRecordStatsToEmbed(builder, team);
 

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaRecordCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaRecordCommand.cs
@@ -20,10 +20,13 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
+            return GetEmbed(team);
+        }
+
+        internal static Embed GetEmbed(Team team)
+        {
             EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
-
             AddRecordStatsToEmbed(builder, team);
-
             return builder.Build();
         }
 

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaRecordUserCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaRecordUserCommand.cs
@@ -1,0 +1,22 @@
+﻿using Discord.Bot;
+using Discord.Bot.Utils;
+using Discord.WebSocket;
+using PlayCEASharp.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public class CeaRecordUserCommand : CeaUserCommand
+    {
+        public override string Name => "CEA Record";
+
+        public override async Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient, Team team)
+        {
+            await command.RespondAsync(embeds:new Embed[] { CeaRecordCommand.GetEmbed(team)}, ephemeral:true);
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaTeamCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaTeamCommand.cs
@@ -19,6 +19,11 @@ namespace Discord.Cea
 
         internal override Embed Run(SocketSlashCommand command, DiscordSocketClient client, IReadOnlyDictionary<SlashCommandOptions, string> options, Team team)
         {
+            return GetEmbed(team);
+        }
+
+        internal static Embed GetEmbed(Team team)
+        {
             EmbedBuilder builder = new EmbedBuilder().WithThumbnailUrl(team.ImageURL);
             StringBuilder sb = new();
             sb.AppendLine($"Current Rank: {team.Rank} [{team.Stats.MatchWins}-{team.Stats.MatchLosses}]");

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/CeaTeamUserCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/CeaTeamUserCommand.cs
@@ -1,0 +1,22 @@
+﻿using Discord.Bot;
+using Discord.Bot.Utils;
+using Discord.WebSocket;
+using PlayCEASharp.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public class CeaTeamUserCommand : CeaUserCommand
+    {
+        public override string Name => "CEA Team";
+
+        public override async Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient, Team team)
+        {
+            await command.RespondAsync(embeds:new Embed[] { CeaTeamCommand.GetEmbed(team)}, ephemeral:true);
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/Contract/CeaSlashCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/Contract/CeaSlashCommand.cs
@@ -41,7 +41,7 @@ namespace Discord.Cea
             this.subCommands = subCommands.ToDictionary(c => c.OptionBuilder.Name);
         }
 
-        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient, Guild guild)
+        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient)
         {
             var subCommand = command.Data.Options.Where(o => o.Type.Equals(ApplicationCommandOptionType.SubCommand)).First();
             IReadOnlyDictionary<SlashCommandOptions, string> options = SlashCommandUtils.OptionsToDictionary(subCommand.Options);

--- a/Bot/Discord.Bot.Extensions/Cea/Commands/Contract/CeaUserCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/Contract/CeaUserCommand.cs
@@ -1,0 +1,44 @@
+﻿using Discord.Bot;
+using Discord.Bot.Utils;
+using Discord.WebSocket;
+using PlayCEASharp.DataModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Cea
+{
+    public abstract class CeaUserCommand : UserCommand
+    {
+        public override bool DefaultPermissions => true;
+
+        public override bool IsGlobal => true;
+
+        public override Dictionary<ulong, List<ApplicationCommandPermission>> GuildIdsAndPermissions => GuildIdMappings.defaultSlashCommandPermissions;
+
+        public override async Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient)
+        {
+            Team t = TeamResolver.ResolveUsersTeam(command.Data.Member);
+            if (t == null)
+            {
+                await command.RespondAsync("That user is not on a team.", ephemeral: true);
+                return;
+            }
+
+            await HandleCommandAsync(command, client, storageClient, t);
+        }
+
+        public abstract Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient, Team team);
+
+        public override ApplicationCommandProperties Build()
+        {
+            var builder = new UserCommandBuilder()
+                    .WithName(this.Name)
+                    .WithDefaultPermission(this.DefaultPermissions);
+
+            return builder.Build();
+        }
+    }
+}

--- a/Bot/Discord.Bot.Extensions/Cea/Utils/TeamResolver.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Utils/TeamResolver.cs
@@ -9,21 +9,11 @@ namespace Discord.Cea
 {
     public static class TeamResolver
     {
-        internal static Team ResolveTeam(string team, SocketUser user)
+        internal static Team ResolveUsersTeam(SocketUser user)
         {
             League league = LeagueManager.League;
-            Team t;
-            if (team != null)
-            {
-                t = league.Bracket.Teams.Where(t => t.Name.Contains(team, StringComparison.OrdinalIgnoreCase)).First();
-            }
-            else
-            {
-                string discordId = $"{user.Username}#{user.Discriminator}";
-                t = league.PlayerDiscordLookup[discordId];
-            }
-
-            return t;
+            string discordId = $"{user.Username}#{user.Discriminator}";
+            return league.PlayerDiscordLookup.ContainsKey(discordId) ? league.PlayerDiscordLookup[discordId] : null;
         }
 
         internal static List<Team> ResolveTeam(IReadOnlyDictionary<SlashCommandOptions, string> options, SocketUser user)

--- a/Bot/Discord.Bot.Extensions/Recruiting/Commands/RecruitingCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Recruiting/Commands/RecruitingCommand.cs
@@ -27,8 +27,10 @@ namespace TyniBot.Commands
 
         public override bool IsGlobal => false;
 
-        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient, Guild guild)
+        public override async Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient)
         {
+            var guild = await Guild.GetGuildAsync(command.GuildId.Value, storageClient);
+
             if (guild.RecruitingChannelId == default)
             {
                 await command.RespondAsync("Channel is not part of a guild that supports recruiting", ephemeral: true);

--- a/Bot/TyniBot.csproj
+++ b/Bot/TyniBot.csproj
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.7.2" />
+    <PackageReference Include="Discord.Net" Version="3.8.1" />
     <PackageReference Include="LiteDB" Version="5.0.12" />
 	<PackageReference Include="Polly" Version="7.2.3" />
-	<PackageReference Include="PlayCEASharp" Version="0.1.0" />
+	<PackageReference Include="PlayCEASharp" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Discord.Bot/Commands/ApplicationCommand.cs
+++ b/Discord.Bot/Commands/ApplicationCommand.cs
@@ -13,8 +13,6 @@ namespace Discord.Bot
     {
         public abstract string Name { get; }
 
-        public abstract string Description { get; }
-
         public abstract bool DefaultPermissions { get; }
 
         public abstract bool IsGlobal { get; }

--- a/Discord.Bot/Commands/UserCommand.cs
+++ b/Discord.Bot/Commands/UserCommand.cs
@@ -10,20 +10,17 @@ using Discord.Bot.Utils;
 
 namespace Discord.Bot
 {
-    public abstract class SlashCommand : ApplicationCommand
+    public abstract class UserCommand : ApplicationCommand
     {
-        public abstract string Description { get; }
-
         public override ApplicationCommandProperties Build()
         {
 
-            var builder = new SlashCommandBuilder()
+            var builder = new UserCommandBuilder()
                     .WithName(this.Name)
-                    .WithDescription(this.Description)
                     .WithDefaultPermission(this.DefaultPermissions);
             return builder.Build();
         }
 
-        public abstract Task HandleCommandAsync(SocketSlashCommand command, DiscordSocketClient client, StorageClient storageClient);
+        public abstract Task HandleCommandAsync(SocketUserCommand command, DiscordSocketClient client, StorageClient storageClient);
     }
 }


### PR DESCRIPTION
Added support for UserCommands, then added CEA implementations for them.
User commands take no arguments, but target a specific user. They show up in the right click menu on a user under Apps.

Idea is if you wanted to quickly check someone's next match or what team they were on you could right click instead of specifying that user as an argument in the slash commands.

They don't allow for subcommand bundling like slash commands so each one has to be registered in TyniBotHost independently.