### PR TITLE
Unregister /cea commands.

### DIFF
--- a/Bot/Discord.Bot.Extensions/Cea/Commands/Contract/CeaSlashCommand.cs
+++ b/Bot/Discord.Bot.Extensions/Cea/Commands/Contract/CeaSlashCommand.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Cea
 {
+    [Obsolete("This functionality is handled by a different CEA bot now.")]
     public class CeaSlashCommand : SlashCommand
     {
         public override string Name => "cea";

--- a/Bot/TynibotHost.cs
+++ b/Bot/TynibotHost.cs
@@ -36,12 +36,6 @@ namespace TyniBot
             new VersionSlashCommand(),
             new RecruitingCommand(),
             new AdminRecruitingCommand(),
-            new CeaSlashCommand(),
-            new CeaTeamUserCommand(),
-            new CeaPreviewUserCommand(),
-            new CeaHistoryUserCommand(),
-            new CeaNextUserCommand(),
-            new CeaRecordUserCommand(),
         };
 
         private readonly Dictionary<string, SlashCommand> SlashCommandDictionary;
@@ -144,7 +138,7 @@ namespace TyniBot
 
         private async Task ReadyAsync()
         {
-            /* //uncomment to remove all commands before reregistering
+            //uncomment to remove all commands before reregistering
             await Client.Rest.DeleteAllGlobalCommandsAsync();
 
             var guilds = await Client.Rest.GetGuildsAsync();
@@ -158,8 +152,7 @@ namespace TyniBot
                     await command.DeleteAsync();
                 }
             }
-
-            */
+            
 
             foreach (var applicationCommand in ApplicationCommands)
             {


### PR DESCRIPTION
/cea command functionality is being moved to PlayCEA Bot, which will be present in multiple discord servers.
In order to avoid hinting for the wrong bot - I'm un-registering the command from TyniBot, but leaving all of the code in case we decide we would rather use tynibot than the playcea bot, although I'm not planning on maintaining both locations.